### PR TITLE
Enable Gemini streaming and fix OG/Twitter cards

### DIFF
--- a/js/gemini.js
+++ b/js/gemini.js
@@ -33,6 +33,96 @@ function buildUrl({ model, apiKey }) {
   return `https://generativelanguage.googleapis.com/v1beta/models/${m}:generateContent?key=${apiKey}`;
 }
 
+function buildStreamUrl({ model, apiKey }) {
+  const m = encodeURIComponent(String(model));
+  // SSE stream
+  return `https://generativelanguage.googleapis.com/v1beta/models/${m}:streamGenerateContent?alt=sse&key=${apiKey}`;
+}
+
+function extractTextFromCandidatePayload(payload) {
+  if (!payload) return '';
+
+  const candidate = Array.isArray(payload?.candidates) ? payload.candidates[0] : null;
+  const parts = candidate?.content?.parts;
+  if (!Array.isArray(parts)) return '';
+  return parts
+    .map((p) => (p && typeof p.text === 'string' ? p.text : ''))
+    .filter(Boolean)
+    .join('');
+}
+
+async function consumeSseText({ response, onTextDelta }) {
+  if (!response?.body || typeof response.body.getReader !== 'function') {
+    throw new Error('ストリーミングに対応していない環境です。');
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder('utf-8');
+
+  let buffer = '';
+  let accumulated = '';
+
+  const flushEvent = (rawEvent) => {
+    const lines = String(rawEvent || '')
+      .replace(/\r\n/g, '\n')
+      .split('\n');
+    const dataLines = lines
+      .map((l) => l.trimEnd())
+      .filter((l) => l.startsWith('data:'))
+      .map((l) => l.slice('data:'.length).trimStart());
+    if (!dataLines.length) return;
+    const dataStr = dataLines.join('\n').trim();
+    if (!dataStr || dataStr === '[DONE]') return;
+
+    let parsed;
+    try {
+      parsed = JSON.parse(dataStr);
+    } catch {
+      return;
+    }
+
+    const payloads = Array.isArray(parsed) ? parsed : [parsed];
+    for (const payload of payloads) {
+      const text = extractTextFromCandidatePayload(payload);
+      if (!text) continue;
+
+      // The API may send full-so-far text or incremental chunks; normalize to delta.
+      let delta = text;
+      if (accumulated && text.startsWith(accumulated)) {
+        delta = text.slice(accumulated.length);
+        accumulated = text;
+      } else {
+        accumulated += text;
+      }
+
+      if (delta) onTextDelta?.(delta, accumulated);
+    }
+  };
+
+  while (true) {
+    // eslint-disable-next-line no-await-in-loop
+    const { value, done } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    buffer = buffer.replace(/\r\n/g, '\n');
+
+    // SSE events are separated by a blank line
+    let sep;
+    // eslint-disable-next-line no-cond-assign
+    while ((sep = buffer.indexOf('\n\n')) !== -1) {
+      const rawEvent = buffer.slice(0, sep);
+      buffer = buffer.slice(sep + 2);
+      flushEvent(rawEvent);
+    }
+  }
+
+  // Flush remaining buffer if it ends without the final separator.
+  if (buffer.trim()) flushEvent(buffer);
+
+  return accumulated;
+}
+
 export async function callGemini({ userPrompt, systemPrompt, onRequireApiKey }) {
   const apiKey = getApiKey();
   if (!apiKey) {
@@ -97,6 +187,86 @@ export async function callGemini({ userPrompt, systemPrompt, onRequireApiKey }) 
       } catch (e) {
         lastError = e;
         if (i === 2) break;
+        await new Promise((r) => setTimeout(r, delays[i]));
+      }
+    }
+  }
+
+  const msg = lastError?.message ? String(lastError.message) : '不明なエラー';
+  return `エラーが発生しました: ${msg}`;
+}
+
+export async function callGeminiStream({
+  userPrompt,
+  systemPrompt,
+  onRequireApiKey,
+  onTextDelta,
+}) {
+  const apiKey = getApiKey();
+  if (!apiKey) {
+    onRequireApiKey?.();
+    return null;
+  }
+
+  const payload = {
+    contents: [{ parts: [{ text: userPrompt }] }],
+    systemInstruction: { parts: [{ text: systemPrompt }] },
+  };
+
+  const delays = [1000, 2000, 4000];
+  const models = getModelCandidates();
+  let lastError = null;
+
+  for (const model of models) {
+    const url = buildStreamUrl({ model, apiKey });
+
+    for (let i = 0; i < 3; i += 1) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+          if (response.status === 404) {
+            const detail = await readErrorMessage(response);
+            lastError = new Error(detail || `Server Error: 404 (model: ${model})`);
+            break;
+          }
+
+          if (response.status === 400 || response.status === 401 || response.status === 403) {
+            const detail = await readErrorMessage(response);
+            throw new Error(
+              detail || 'APIキーが無効であるか、権限がありません。設定を確認してください。'
+            );
+          }
+
+          if (response.status === 429) {
+            const detail = await readErrorMessage(response);
+            lastError = new Error(detail || '混雑しています（429）。少し待って再試行してください。');
+            if (i === 2) throw lastError;
+            // eslint-disable-next-line no-await-in-loop
+            await new Promise((r) => setTimeout(r, delays[i]));
+            continue;
+          }
+
+          const detail = await readErrorMessage(response);
+          lastError = new Error(detail || `Server Error: ${response.status}`);
+          if (i === 2) throw lastError;
+          // eslint-disable-next-line no-await-in-loop
+          await new Promise((r) => setTimeout(r, delays[i]));
+          continue;
+        }
+
+        // eslint-disable-next-line no-await-in-loop
+        const finalText = await consumeSseText({ response, onTextDelta });
+        return finalText || '回答を生成できませんでした。';
+      } catch (e) {
+        lastError = e;
+        if (i === 2) break;
+        // eslint-disable-next-line no-await-in-loop
         await new Promise((r) => setTimeout(r, delays[i]));
       }
     }

--- a/share/architect.html
+++ b/share/architect.html
@@ -6,15 +6,21 @@
   <title>AWS Study Navigator - アーキテクト</title>
 
   <!-- OG/Twitter for X preview image -->
+  <link rel="canonical" href="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/share/architect.html" />
   <meta property="og:locale" content="ja_JP" />
   <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="AWS Study Navigator" />
+  <meta property="og:url" content="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/share/architect.html" />
   <meta property="og:title" content="AWS Study Navigator" />
   <meta property="og:description" content="称号を解放しました：アーキテクト" />
-  <meta property="og:image" content="../assets/og/architect.png" />
+  <meta property="og:image" content="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/assets/og/architect.png" />
+  <meta property="og:image:secure_url" content="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/assets/og/architect.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:image" content="../assets/og/architect.png" />
+  <meta name="twitter:title" content="AWS Study Navigator" />
+  <meta name="twitter:description" content="称号を解放しました：アーキテクト" />
+  <meta name="twitter:image" content="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/assets/og/architect.png" />
 
   <script>
     // Human-friendly redirect (bots usually don't run JS)

--- a/share/beginner.html
+++ b/share/beginner.html
@@ -6,15 +6,21 @@
   <title>AWS Study Navigator - ビギナー</title>
 
   <!-- OG/Twitter for X preview image -->
+  <link rel="canonical" href="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/share/beginner.html" />
   <meta property="og:locale" content="ja_JP" />
   <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="AWS Study Navigator" />
+  <meta property="og:url" content="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/share/beginner.html" />
   <meta property="og:title" content="AWS Study Navigator" />
   <meta property="og:description" content="称号を解放しました：ビギナー" />
-  <meta property="og:image" content="../assets/og/beginner.png" />
+  <meta property="og:image" content="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/assets/og/beginner.png" />
+  <meta property="og:image:secure_url" content="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/assets/og/beginner.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:image" content="../assets/og/beginner.png" />
+  <meta name="twitter:title" content="AWS Study Navigator" />
+  <meta name="twitter:description" content="称号を解放しました：ビギナー" />
+  <meta name="twitter:image" content="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/assets/og/beginner.png" />
 
   <script>
     // Human-friendly redirect (bots usually don't run JS)

--- a/share/rookie.html
+++ b/share/rookie.html
@@ -6,15 +6,21 @@
   <title>AWS Study Navigator - ルーキー</title>
 
   <!-- OG/Twitter for X preview image -->
+  <link rel="canonical" href="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/share/rookie.html" />
   <meta property="og:locale" content="ja_JP" />
   <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="AWS Study Navigator" />
+  <meta property="og:url" content="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/share/rookie.html" />
   <meta property="og:title" content="AWS Study Navigator" />
   <meta property="og:description" content="称号を解放しました：ルーキー" />
-  <meta property="og:image" content="../assets/og/rookie.png" />
+  <meta property="og:image" content="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/assets/og/rookie.png" />
+  <meta property="og:image:secure_url" content="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/assets/og/rookie.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:image" content="../assets/og/rookie.png" />
+  <meta name="twitter:title" content="AWS Study Navigator" />
+  <meta name="twitter:description" content="称号を解放しました：ルーキー" />
+  <meta name="twitter:image" content="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/assets/og/rookie.png" />
 
   <script>
     // Human-friendly redirect (bots usually don't run JS)

--- a/share/senior_architect.html
+++ b/share/senior_architect.html
@@ -6,15 +6,21 @@
   <title>AWS Study Navigator - シニアアーキテクト</title>
 
   <!-- OG/Twitter for X preview image -->
+  <link rel="canonical" href="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/share/senior_architect.html" />
   <meta property="og:locale" content="ja_JP" />
   <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="AWS Study Navigator" />
+  <meta property="og:url" content="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/share/senior_architect.html" />
   <meta property="og:title" content="AWS Study Navigator" />
   <meta property="og:description" content="称号を解放しました：シニアアーキテクト" />
-  <meta property="og:image" content="../assets/og/senior-architect.png" />
+  <meta property="og:image" content="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/assets/og/senior-architect.png" />
+  <meta property="og:image:secure_url" content="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/assets/og/senior-architect.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:image" content="../assets/og/senior-architect.png" />
+  <meta name="twitter:title" content="AWS Study Navigator" />
+  <meta name="twitter:description" content="称号を解放しました：シニアアーキテクト" />
+  <meta name="twitter:image" content="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/assets/og/senior-architect.png" />
 
   <script>
     // Human-friendly redirect (bots usually don't run JS)

--- a/share/solution_architect.html
+++ b/share/solution_architect.html
@@ -6,15 +6,21 @@
   <title>AWS Study Navigator - ソリューションアーキテクト</title>
 
   <!-- OG/Twitter for X preview image -->
+  <link rel="canonical" href="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/share/solution_architect.html" />
   <meta property="og:locale" content="ja_JP" />
   <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="AWS Study Navigator" />
+  <meta property="og:url" content="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/share/solution_architect.html" />
   <meta property="og:title" content="AWS Study Navigator" />
   <meta property="og:description" content="称号を解放しました：ソリューションアーキテクト" />
-  <meta property="og:image" content="../assets/og/solution_architect.png" />
+  <meta property="og:image" content="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/assets/og/solution_architect.png" />
+  <meta property="og:image:secure_url" content="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/assets/og/solution_architect.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:image" content="../assets/og/solution_architect.png" />
+  <meta name="twitter:title" content="AWS Study Navigator" />
+  <meta name="twitter:description" content="称号を解放しました：ソリューションアーキテクト" />
+  <meta name="twitter:image" content="https://kenta-matsuda.github.io/Kenta-Matsuda.github.io-aws-study/assets/og/solution_architect.png" />
 
   <script>
     // Human-friendly redirect (bots usually don't run JS)


### PR DESCRIPTION
This pull request introduces streaming support for Gemini AI responses in the UI, improving user experience by delivering answers incrementally as they are generated. It also enhances social sharing pages with improved Open Graph and Twitter metadata for better link previews.

The most important changes are:

### Streaming Gemini AI Responses

* Added a streaming API call (`callGeminiStream`) and SSE (Server-Sent Events) handling logic in `gemini.js` to enable incremental AI response delivery, including error handling and fallback to non-streaming when unsupported. [[1]](diffhunk://#diff-cd6440a7d13f98719798e321b93c5a2f944d8389a015683bc594f823a9e68c6fR36-R125) [[2]](diffhunk://#diff-cd6440a7d13f98719798e321b93c5a2f944d8389a015683bc594f823a9e68c6fR198-R277)
* Updated UI logic in `ui.js` to use streaming responses for term explanations and answer generation, updating the modal content in real time and falling back to the original non-streaming method as needed. [[1]](diffhunk://#diff-bb6a80effd4bdae44c8f01daaf6c168f489eab915d38f6139d41a690e6575ab0L1-R1) [[2]](diffhunk://#diff-bb6a80effd4bdae44c8f01daaf6c168f489eab915d38f6139d41a690e6575ab0R1133-R1138) [[3]](diffhunk://#diff-bb6a80effd4bdae44c8f01daaf6c168f489eab915d38f6139d41a690e6575ab0L1156-R1176) [[4]](diffhunk://#diff-bb6a80effd4bdae44c8f01daaf6c168f489eab915d38f6139d41a690e6575ab0L1197-R1226)

### Social Sharing Metadata Improvements

* Updated all share HTML pages to include canonical URLs, consistent Open Graph and Twitter meta tags (such as `og:site_name`, `og:url`, `twitter:title`, and secure image URLs), ensuring rich previews when sharing links on social media. [[1]](diffhunk://#diff-dec0fa2ae243f802b628fab01d918adbf695cdc5774c43736ae877bc25687e59R9-R23) [[2]](diffhunk://#diff-ffbe6f4efc46bd9dae5eb1d9c6973c6dbd4caa612671e1fd63e03e88f3070728R9-R23) [[3]](diffhunk://#diff-24dc95e94ee884e591fb7420d21309bdcc3f4ab881100ba837dadacefb9e191fR9-R23) [[4]](diffhunk://#diff-418c7f1b993e43888ed99574a4a40d934180adebcf6fd704c28846bd30ec34a3R9-R23) [[5]](diffhunk://#diff-4bc723d12e807abf27277d6b0104ac3a1d6c48f35e06743b476e0718f94f9166R9-R23)