### PR TITLE
入力文字数を100文字に制限

### DIFF
--- a/index.html
+++ b/index.html
@@ -1104,9 +1104,9 @@
                 </div>
                 <div class="mb-4">
                     <label class="block text-gray-700 text-sm font-bold mb-2" for="feedbackTextarea">フィードバック内容</label>
-                    <textarea id="feedbackTextarea" rows="5" maxlength="1000" placeholder="改善してほしい点、追加してほしい機能などを自由にお書きください。" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline resize-y"></textarea>
+                    <textarea id="feedbackTextarea" rows="5" maxlength="100" placeholder="改善してほしい点、追加してほしい機能などを100文字以内でお書きください。" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline resize-y"></textarea>
                     <div class="flex justify-end mt-1">
-                        <span id="feedbackCharCount" class="text-xs text-gray-400">0 / 1000</span>
+                        <span id="feedbackCharCount" class="text-xs text-gray-400">0 / 100</span>
                     </div>
                 </div>
                 <div id="feedbackMessage" class="text-sm mb-4 hidden"></div>

--- a/js/ui.js
+++ b/js/ui.js
@@ -2307,6 +2307,8 @@ function highlightHtml(escapedText, termLower) {
 }
 
 // --- Feedback ---
+const FEEDBACK_MAX_LENGTH = 100;
+
 function wireFeedbackHandlers({ els }) {
   if (!els.feedbackBtn || !els.feedbackModal) return;
 
@@ -2343,9 +2345,9 @@ function openFeedbackModal(els) {
 function updateFeedbackCharCount(els) {
   if (!els.feedbackCharCount || !els.feedbackTextarea) return;
   const len = (els.feedbackTextarea.value || '').length;
-  els.feedbackCharCount.textContent = `${len} / 1000`;
-  els.feedbackCharCount.classList.toggle('text-red-500', len > 950);
-  els.feedbackCharCount.classList.toggle('text-gray-400', len <= 950);
+  els.feedbackCharCount.textContent = `${len} / ${FEEDBACK_MAX_LENGTH}`;
+  els.feedbackCharCount.classList.toggle('text-orange-500', len > FEEDBACK_MAX_LENGTH * 0.95);
+  els.feedbackCharCount.classList.toggle('text-gray-400', len <= FEEDBACK_MAX_LENGTH * 0.95);
 }
 
 function submitFeedback(els) {
@@ -2356,8 +2358,8 @@ function submitFeedback(els) {
     showInlineMessage(els.feedbackMessage, 'フィードバック内容を入力してください。', 'text-red-600');
     return;
   }
-  if (text.length > 1000) {
-    showInlineMessage(els.feedbackMessage, '1000文字以内で入力してください。', 'text-red-600');
+  if (text.length > FEEDBACK_MAX_LENGTH) {
+    showInlineMessage(els.feedbackMessage, `${FEEDBACK_MAX_LENGTH}文字以内で入力してください。`, 'text-red-600');
     return;
   }
 
@@ -2381,20 +2383,12 @@ function sendFeedbackToGa({ category, text }) {
     const gtag = window.gtag;
     if (typeof gtag !== 'function') return;
 
-    // GA4 event parameters are limited to 100 chars per value for standard reporting,
-    // but custom events can send longer strings in exploration reports.
-    // Split long text into chunks for reliable capture.
-    const maxChunk = 500;
-    const chunks = [];
-    for (let i = 0; i < text.length; i += maxChunk) {
-      chunks.push(text.slice(i, i + maxChunk));
-    }
+    const feedbackText = String(text || '').slice(0, FEEDBACK_MAX_LENGTH);
 
     gtag('event', 'user_feedback', {
       feedback_category: category,
-      feedback_text: chunks[0] || '',
-      feedback_text_2: chunks[1] || '',
-      feedback_length: text.length,
+      feedback_text: feedbackText,
+      feedback_length: feedbackText.length,
     });
   } catch {
     // ignore


### PR DESCRIPTION
This pull request updates the feedback functionality to enforce a stricter character limit of 100 characters (down from 1000) for user feedback. The UI, validation logic, and analytics reporting have all been updated to reflect this new limit.

**Feedback character limit enforcement and UI updates:**

* Changed the feedback textarea in `index.html` to limit input to 100 characters, updated the placeholder to mention the new limit, and adjusted the character counter display accordingly.
* Added a `FEEDBACK_MAX_LENGTH` constant in `js/ui.js` and updated all relevant logic to use this value for validation, character counting, and color warnings. [[1]](diffhunk://#diff-bb6a80effd4bdae44c8f01daaf6c168f489eab915d38f6139d41a690e6575ab0R2310-R2311) [[2]](diffhunk://#diff-bb6a80effd4bdae44c8f01daaf6c168f489eab915d38f6139d41a690e6575ab0L2346-R2350) [[3]](diffhunk://#diff-bb6a80effd4bdae44c8f01daaf6c168f489eab915d38f6139d41a690e6575ab0L2359-R2362)

**Analytics reporting consistency:**

* Updated the Google Analytics feedback event logic to only send up to 100 characters, removing chunking logic for longer feedback and ensuring the reported feedback length matches the enforced limit.